### PR TITLE
Assign a name to the struct Body

### DIFF
--- a/include/body.h
+++ b/include/body.h
@@ -13,12 +13,12 @@ struct MyVector2 {
    double x;
    double y;
 };
-typedef struct Body {
+typedef struct body {
     struct MyVector2 pos;
     struct MyVector2 p;
     double m;
     Texture2D color;
-};
+} Body;
 
 struct MyVector2 vectorSubtract(struct MyVector2 a, struct MyVector2 b);
 struct MyVector2 vectorAdd(struct MyVector2 a, struct MyVector2 b);

--- a/include/setup.h
+++ b/include/setup.h
@@ -1,1 +1,1 @@
-void setup(struct Body *red, struct Body *green, struct Body *blue);
+void setup(Body *red, Body *green, Body *blue);

--- a/main.c
+++ b/main.c
@@ -13,9 +13,9 @@
 int main() {
     
     InitWindow(1920, 1080, "Three Body Problem");
-    struct Body red;
-    struct Body blue;
-    struct Body green;
+    Body red;
+    Body blue;
+    Body green;
     green.color = LoadTexture("assets/green.png");
     red.color = LoadTexture("assets/red.png");
     blue.color = LoadTexture("assets/blue.png");

--- a/setup.c
+++ b/setup.c
@@ -1,6 +1,6 @@
 #include "include/raylib.h"
 #include "include/body.h"
-void setup(struct Body *red, struct Body *green, struct Body *blue) {
+void setup(Body *red, Body *green, Body *blue) {
     int shape = 0;
     Vector2 cursorPos;
 


### PR DESCRIPTION
Typedef is used to name structs so you do not have to invoke the keyword "struct" every time you want to use it.
